### PR TITLE
workaround for the double SIGINT problem

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -38,8 +38,10 @@ async function listen() {
   });
 
   process.on("SIGINT", () => {
-    console.log("\n[blivec] closing...");
-    con.close();
+    if (!con.closed) {
+      console.log("\n[blivec] closing...");
+      con.close();
+    }
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,10 @@ export class Connection {
     socket.on("data", this._on_data.bind(this));
   }
 
+  get closed() {
+    return this._closed;
+  }
+
   _on_ready() {
     clearTimeout(this.timer_reconnect);
     if (this.info) {


### PR DESCRIPTION
用 npx 跑，发一次 ctrl-c 会收到两次 SIGINT